### PR TITLE
✨ feat(message): support sender title fallback, fix #160

### DIFF
--- a/packages/core/src/utils/message.ts
+++ b/packages/core/src/utils/message.ts
@@ -61,7 +61,12 @@ export function convertToCoreMessage(message: Api.Message): Result<CoreMessage> 
 
   let fromName = ''
   if (sender instanceof Api.User) {
-    fromName = `${sender.firstName ?? ''}${sender.lastName && ` ${sender.lastName}`}`
+    if ([sender.firstName,sender.lastName].some(Boolean)) {
+      fromName = [sender.firstName, sender.lastName].join(' ')
+    }
+    else {
+      fromName = sender.username ?? String(sender.id)
+    }
   }
   else {
     fromName = sender?.title ?? String(senderId)


### PR DESCRIPTION
 - Use sender title if available
 - Fallback to sender's ID as username if title isn't available