### PR TITLE
refactor: custom backend url

### DIFF
--- a/apps/electron/electron.vite.config.ts
+++ b/apps/electron/electron.vite.config.ts
@@ -83,13 +83,13 @@ export default defineConfig({
     server: {
       proxy: {
         '/api': {
-          target: 'http://localhost:3000',
+          target: process.env.BACKEND_URL ?? 'http://localhost:3000',
           changeOrigin: true,
           // Remove /api prefix when forwarding to target
           rewrite: path => path.replace(/^\/api/, ''),
         },
         '/ws': {
-          target: 'http://localhost:3000',
+          target: process.env.BACKEND_URL ?? 'http://localhost:3000',
           changeOrigin: true,
           ws: true,
         },

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -43,13 +43,13 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:3000',
+        target: process.env.BACKEND_URL ?? 'http://localhost:3000',
         changeOrigin: true,
         // Remove /api prefix when forwarding to target
         rewrite: path => path.replace(/^\/api/, ''),
       },
       '/ws': {
-        target: 'http://localhost:3000',
+        target: process.env.BACKEND_URL ?? 'http://localhost:3000',
         changeOrigin: true,
         ws: true,
       },


### PR DESCRIPTION
….BACKEND_URL

- update frontend API target to use environment variable BACKEND_URL
- This allows for flexibility when running applications in different environments